### PR TITLE
Fix: Resolve CSRF error in Dockerized environment

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,7 @@ services:
     environment:
       - NODE_ENV=production
       - PUBLIC_BASE_URL=${PUBLIC_BASE_URL:-http://localhost:3000}
+      - ORIGIN=${PUBLIC_BASE_URL:-http://localhost:3000}
       - SESSION_SECRET=${SESSION_SECRET:-change_this_in_production}
       - SESSION_COOKIE_SECURE=${SESSION_COOKIE_SECURE:-false}
       - DATA_DIR=/home/node/app/data

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -26,22 +26,7 @@ const handleAuth = async ({ event, resolve }: any) => {
   return await resolve(event);
 };
 
-/**
- * CSRF protection handler
- * Disables cross-site POST protection in development for easier testing
- * @type {import('@sveltejs/kit').Handle}
- */
-const handleCSRF = async ({ event, resolve }: any) => {
-  const response = await resolve(event, {
-    // In development, we'll allow cross-site form submissions for easier testing
-    // In production, this should be set to true
-    transformPageChunk: ({ html }: any) => html,
-  });
-
-  return response;
-};
-
-export const handle = sequence(handleAuth, handleCSRF);
+export const handle = sequence(handleAuth);
 
 export function handleError({ error }: any) {
   console.error("Server error:", error);


### PR DESCRIPTION
The application was throwing a "Cross-site POST form submissions are forbidden" error when a new user tried to sign up in a Docker container.

This was due to SvelteKit's default CSRF protection kicking in because the application, when run in Docker, is not in `dev` mode, and the perceived origin of the request did not match what SvelteKit expected its own origin to be.

The fix involves two main changes:
1. I refactored `src/hooks.server.ts` to remove a custom `handleCSRF` function that was not correctly managing CSRF settings. This allows SvelteKit's default, more robust CSRF protection to take effect.
2. I updated `docker-compose.yml` to include an `ORIGIN` environment variable for the SvelteKit service. This variable is set to the value of `PUBLIC_BASE_URL` (defaulting to `http://localhost:3000`), explicitly telling SvelteKit its expected public-facing origin for CSRF checks.

These changes ensure that SvelteKit's CSRF protection is correctly configured for the Docker environment, resolving the signup error.