### PR TITLE
feat: Add AI service abstraction and initial implementations

### DIFF
--- a/src/lib/server/ai/.keep
+++ b/src/lib/server/ai/.keep
@@ -1,0 +1,1 @@
+# This file is intentionally left blank to ensure the directory is tracked by Git.

--- a/src/lib/server/ai/AiService.test.ts
+++ b/src/lib/server/ai/AiService.test.ts
@@ -1,0 +1,22 @@
+import { AiService } from './AiService';
+import { describe, it, expect } from 'vitest';
+
+// Dummy implementation for testing AiService
+class DummyAiService extends AiService {
+  async sendPrompt(prompt: string): Promise<string> {
+    return `Dummy response to: ${prompt}`;
+  }
+}
+
+describe('AiService', () => {
+  it('should allow a concrete implementation to be created', () => {
+    const dummyService = new DummyAiService();
+    expect(dummyService).toBeInstanceOf(AiService);
+    expect(dummyService).toBeInstanceOf(DummyAiService);
+  });
+
+  it('should have a sendPrompt method', () => {
+    const dummyService = new DummyAiService();
+    expect(typeof dummyService.sendPrompt).toBe('function');
+  });
+});

--- a/src/lib/server/ai/AiService.ts
+++ b/src/lib/server/ai/AiService.ts
@@ -1,0 +1,3 @@
+export abstract class AiService {
+  abstract sendPrompt(prompt: string): Promise<string>;
+}

--- a/src/lib/server/ai/ClaudeService.test.ts
+++ b/src/lib/server/ai/ClaudeService.test.ts
@@ -1,0 +1,18 @@
+import { ClaudeService } from './ClaudeService';
+import { describe, it, expect } from 'vitest';
+
+describe('ClaudeService', () => {
+  const DUMMY_API_KEY = 'test-claude-api-key';
+
+  it('should be able to be instantiated', () => {
+    const claudeService = new ClaudeService(DUMMY_API_KEY);
+    expect(claudeService).toBeInstanceOf(ClaudeService);
+  });
+
+  it('should return the placeholder response from sendPrompt', async () => {
+    const claudeService = new ClaudeService(DUMMY_API_KEY);
+    const prompt = 'Hello Claude';
+    const response = await claudeService.sendPrompt(prompt);
+    expect(response).toBe(`Claude response to: ${prompt}`);
+  });
+});

--- a/src/lib/server/ai/ClaudeService.ts
+++ b/src/lib/server/ai/ClaudeService.ts
@@ -1,0 +1,15 @@
+import { AiService } from './AiService';
+
+export class ClaudeService extends AiService {
+  private readonly apiKey: string;
+
+  constructor(apiKey: string) {
+    super();
+    this.apiKey = apiKey;
+  }
+
+  async sendPrompt(prompt: string): Promise<string> {
+    // TODO: Implement actual Claude API call
+    return `Claude response to: ${prompt}`;
+  }
+}

--- a/src/lib/server/ai/GeminiService.test.ts
+++ b/src/lib/server/ai/GeminiService.test.ts
@@ -1,0 +1,18 @@
+import { GeminiService } from './GeminiService';
+import { describe, it, expect } from 'vitest';
+
+describe('GeminiService', () => {
+  const DUMMY_API_KEY = 'test-gemini-api-key';
+
+  it('should be able to be instantiated', () => {
+    const geminiService = new GeminiService(DUMMY_API_KEY);
+    expect(geminiService).toBeInstanceOf(GeminiService);
+  });
+
+  it('should return the placeholder response from sendPrompt', async () => {
+    const geminiService = new GeminiService(DUMMY_API_KEY);
+    const prompt = 'Hello Gemini';
+    const response = await geminiService.sendPrompt(prompt);
+    expect(response).toBe(`Gemini response to: ${prompt}`);
+  });
+});

--- a/src/lib/server/ai/GeminiService.ts
+++ b/src/lib/server/ai/GeminiService.ts
@@ -1,0 +1,15 @@
+import { AiService } from './AiService';
+
+export class GeminiService extends AiService {
+  private readonly apiKey: string;
+
+  constructor(apiKey: string) {
+    super();
+    this.apiKey = apiKey;
+  }
+
+  async sendPrompt(prompt: string): Promise<string> {
+    // TODO: Implement actual Gemini API call
+    return `Gemini response to: ${prompt}`;
+  }
+}

--- a/src/lib/server/ai/OpenAiService.test.ts
+++ b/src/lib/server/ai/OpenAiService.test.ts
@@ -1,0 +1,18 @@
+import { OpenAiService } from './OpenAiService';
+import { describe, it, expect } from 'vitest';
+
+describe('OpenAiService', () => {
+  const DUMMY_API_KEY = 'test-openai-api-key';
+
+  it('should be able to be instantiated', () => {
+    const openAiService = new OpenAiService(DUMMY_API_KEY);
+    expect(openAiService).toBeInstanceOf(OpenAiService);
+  });
+
+  it('should return the placeholder response from sendPrompt', async () => {
+    const openAiService = new OpenAiService(DUMMY_API_KEY);
+    const prompt = 'Hello OpenAI';
+    const response = await openAiService.sendPrompt(prompt);
+    expect(response).toBe(`OpenAI response to: ${prompt}`);
+  });
+});

--- a/src/lib/server/ai/OpenAiService.ts
+++ b/src/lib/server/ai/OpenAiService.ts
@@ -1,0 +1,15 @@
+import { AiService } from './AiService';
+
+export class OpenAiService extends AiService {
+  private readonly apiKey: string;
+
+  constructor(apiKey: string) {
+    super();
+    this.apiKey = apiKey;
+  }
+
+  async sendPrompt(prompt: string): Promise<string> {
+    // TODO: Implement actual OpenAI API call
+    return `OpenAI response to: ${prompt}`;
+  }
+}


### PR DESCRIPTION
Introduces an abstract `AiService` class defining a contract for interacting with AI models, specifically a `sendPrompt` method.

Adds three concrete implementations:
- `OpenAiService`: For interacting with OpenAI models.
- `GeminiService`: For interacting with Gemini models.
- `ClaudeService`: For interacting with Claude models.

Each service includes a constructor for API key management and a placeholder implementation for the `sendPrompt` method.

Basic unit tests have been added for the abstract class and each concrete service to ensure correct instantiation and placeholder behavior of `sendPrompt`.