### PR TITLE
feat: Add support for local LLM services

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,9 +14,12 @@ PUBLIC_BASE_URL=http://localhost:3000
 NODE_ENV=development
 
 # AI Service Configuration
-# Specifies which AI service provider to use. Options: "openai", "gemini", "claude"
+# Specifies which AI service provider to use. Options: "openai", "gemini", "claude", "local"
 # Default is "openai" if not specified or for backward compatibility with old OPENAI_API_KEY setup.
 AI_SERVICE_PROVIDER="openai"
+# AI_SERVICE_PROVIDER="gemini"
+# AI_SERVICE_PROVIDER="claude"
+# AI_SERVICE_PROVIDER="local"
 
 # API Keys for AI Services
 # Provide the API key for the selected AI_SERVICE_PROVIDER.
@@ -31,6 +34,18 @@ CLAUDE_API_KEY="your_claude_api_key_here"
 # OPENAI_BASE_URI="your_openai_base_uri_if_not_default"
 # GEMINI_BASE_URI="your_gemini_base_uri_if_not_default"
 # CLAUDE_BASE_URI="your_claude_base_uri_if_not_default"
+
+# --- Local LLM Configuration ---
+# Required if AI_SERVICE_PROVIDER is "local" or "localllm"
+# Set this to the base URI of your local LLM API endpoint.
+# The LocalLlmService sends a POST request to this URI with JSON: {"prompt": "your prompt", "stream": false}
+# It expects a JSON response like {"response": "llm answer"} or an OpenAI-compatible format 
+# e.g., {"choices":[{"message":{"content":"..."}}]}.
+
+# Example for Ollama direct generation API (ensure the model is served):
+LOCAL_LLM_BASE_URI="http://localhost:11434/api/generate"
+# Example for an OpenAI-compatible local server (like LM Studio, LocalAI, or Ollama's OpenAI endpoint):
+# LOCAL_LLM_BASE_URI="http://localhost:1234/v1/chat/completions" # Adjust port and path as needed
 
 # Docker-specific environment variables
 # These are set in docker-compose.yml but can be overridden in a .env file

--- a/README.md
+++ b/README.md
@@ -53,10 +53,21 @@ The application can leverage AI services for enhanced functionality. If you wish
     - `"openai"`
     - `"gemini"`
     - `"claude"`
-- Corresponding API Key:
-    - If `AI_SERVICE_PROVIDER="openai"`, set `OPENAI_API_KEY="your_openai_api_key_here"`
-    - If `AI_SERVICE_PROVIDER="gemini"`, set `GEMINI_API_KEY="your_gemini_api_key_here"`
-    - If `AI_SERVICE_PROVIDER="claude"`, set `CLAUDE_API_KEY="your_claude_api_key_here"`
+    - `"local"` (or `"localllm"`)
+- Corresponding API Key / Configuration:
+    - If `AI_SERVICE_PROVIDER="openai"`, set `OPENAI_API_KEY="your_openai_api_key_here"`. You can also optionally set `OPENAI_BASE_URI` if you're using a proxy or a compatible API.
+    - If `AI_SERVICE_PROVIDER="gemini"`, set `GEMINI_API_KEY="your_gemini_api_key_here"`. Optionally set `GEMINI_BASE_URI`.
+    - If `AI_SERVICE_PROVIDER="claude"`, set `CLAUDE_API_KEY="your_claude_api_key_here"`. Optionally set `CLAUDE_BASE_URI`.
+    - If `AI_SERVICE_PROVIDER="local"` or `"localllm"`, set `LOCAL_LLM_BASE_URI`. This is the full base endpoint of your local LLM.
+        - **`LOCAL_LLM_BASE_URI`**: This variable specifies the HTTP endpoint of your locally running Large Language Model.
+            - Example for Ollama (direct API): `LOCAL_LLM_BASE_URI="http://localhost:11434/api/generate"`
+            - Example for an OpenAI-compatible API (like LM Studio, LocalAI, or Ollama's OpenAI endpoint): `LOCAL_LLM_BASE_URI="http://localhost:1234/v1/chat/completions"` (adjust port and path as needed).
+        - **Expected API Behavior for Local LLM:**
+            - The endpoint specified by `LOCAL_LLM_BASE_URI` should be a POST endpoint.
+            - It must accept a JSON request body with the following structure: `{"prompt": "your prompt here", "stream": false}`.
+            - It should return a JSON response. The service supports two common formats:
+                1.  Standard format: `{"response": "The LLM's answer"}`
+                2.  OpenAI-compatible format: `{"choices": [{"message": {"content": "The LLM's answer"}}]}`
 
 ### 3. Start the app
 
@@ -95,8 +106,8 @@ This project is continuously evolving, and we're excited about the future! We ar
 Our roadmap includes:
 
 -   **Broader LLM Support:** We plan to integrate a wider range of Large Language Models to give you more choices. This includes upcoming support for:
-    -   OpenAI's GPT models
-    -   Anthropic's Claude
--   **Self-Hosted LLMs:** We understand the importance of data privacy and control. A key future goal is to enable support for self-hosted LLMs, allowing you to use models running on your own infrastructure.
+    -   Integration with more models from OpenAI (GPT series) and Anthropic (Claude series).
+    -   Enhanced configuration options for different models and providers.
+-   **Self-Hosted LLMs:** Basic support for self-hosted LLMs via a generic API endpoint is now available (see `LOCAL_LLM_BASE_URI` in the configuration section). Future enhancements may include more specific integrations or auto-discovery for popular local LLM servers.
 
 We believe in community-driven development. If you're interested in contributing to these features, or if you have other ideas and suggestions, please don't hesitate to reach out or open an issue. Your input is highly valued!

--- a/src/lib/server/ai/AiServiceFactory.test.ts
+++ b/src/lib/server/ai/AiServiceFactory.test.ts
@@ -1,0 +1,108 @@
+import { AiServiceFactory } from './AiServiceFactory';
+import { LocalLlmService } from './LocalLlmService';
+import { OpenAiService } from './OpenAiService';
+import { GeminiService } from './GeminiService';
+import { ClaudeService } from './ClaudeService';
+
+describe('AiServiceFactory', () => {
+  const originalEnv = { ...process.env }; // Store original environment variables
+
+  beforeEach(() => {
+    // Reset environment variables before each test
+    process.env = { ...originalEnv };
+    // Clear any cached instance or state if the factory implemented caching (not shown in provided factory code)
+    // For example, if AiServiceFactory had a static instance variable, reset it here.
+    // AiServiceFactory.resetInstance(); // Assuming such a method if caching was involved
+  });
+
+  afterAll(() => {
+    // Restore original environment variables after all tests
+    process.env = { ...originalEnv };
+  });
+
+  describe('LocalLlmService Instantiation', () => {
+    test('Test Case 1a: Factory creates LocalLlmService with AI_SERVICE_PROVIDER="local"', () => {
+      process.env.AI_SERVICE_PROVIDER = "local";
+      process.env.LOCAL_LLM_BASE_URI = "http://localhost:11434/api/generate";
+      
+      const instance = AiServiceFactory.getInstance();
+      expect(instance).toBeInstanceOf(LocalLlmService);
+      // Check if the baseUri is correctly passed (optional, requires exposing it or specific behavior)
+      // For LocalLlmService, the constructor takes baseUri. If AiService has a getBaseUri method:
+      // expect((instance as LocalLlmService).getBaseUri()).toBe("http://localhost:11434/api/generate");
+    });
+
+    test('Test Case 1b: Factory creates LocalLlmService with AI_SERVICE_PROVIDER="localllm"', () => {
+      process.env.AI_SERVICE_PROVIDER = "localllm";
+      process.env.LOCAL_LLM_BASE_URI = "http://localhost:11435/v1"; // Different URI for testing alias
+      
+      const instance = AiServiceFactory.getInstance();
+      expect(instance).toBeInstanceOf(LocalLlmService);
+    });
+
+    test('Test Case 2: Factory throws error if LOCAL_LLM_BASE_URI is missing for "local" provider', () => {
+      process.env.AI_SERVICE_PROVIDER = "local";
+      delete process.env.LOCAL_LLM_BASE_URI; // Ensure it's undefined
+      
+      expect(() => AiServiceFactory.getInstance())
+        .toThrow("Missing LOCAL_LLM_BASE_URI for local provider.");
+    });
+
+    test('Factory throws error if LOCAL_LLM_BASE_URI is missing for "localllm" provider', () => {
+      process.env.AI_SERVICE_PROVIDER = "localllm";
+      delete process.env.LOCAL_LLM_BASE_URI;
+      
+      expect(() => AiServiceFactory.getInstance())
+        .toThrow("Missing LOCAL_LLM_BASE_URI for local provider.");
+    });
+  });
+
+  describe('Other AI Service Instantiation (example)', () => {
+    test('Factory creates OpenAiService when AI_SERVICE_PROVIDER="openai"', () => {
+      process.env.AI_SERVICE_PROVIDER = "openai";
+      process.env.OPENAI_API_KEY = "test_openai_key";
+      
+      const instance = AiServiceFactory.getInstance();
+      expect(instance).toBeInstanceOf(OpenAiService);
+    });
+
+    test('Factory throws error if OPENAI_API_KEY is missing for "openai" provider', () => {
+      process.env.AI_SERVICE_PROVIDER = "openai";
+      delete process.env.OPENAI_API_KEY;
+      
+      expect(() => AiServiceFactory.getInstance())
+        .toThrow("Missing OPENAI_API_KEY for openai provider.");
+    });
+  });
+
+  describe('Provider Not Set or Invalid', () => {
+    test('Factory throws error if AI_SERVICE_PROVIDER is not set', () => {
+      delete process.env.AI_SERVICE_PROVIDER;
+      // Assuming the factory defaults to 'openai' if OPENAI_API_KEY is present, 
+      // or throws specific error if provider is truly missing.
+      // Based on current AiServiceFactory, it expects AI_SERVICE_PROVIDER.
+      expect(() => AiServiceFactory.getInstance())
+        .toThrow("Invalid or missing AI_SERVICE_PROVIDER environment variable. Supported values: openai, gemini, claude, local.");
+    });
+
+    test('Factory throws error for an unsupported AI_SERVICE_PROVIDER', () => {
+      process.env.AI_SERVICE_PROVIDER = "unsupported_provider";
+      
+      expect(() => AiServiceFactory.getInstance())
+        .toThrow("Invalid or missing AI_SERVICE_PROVIDER environment variable. Supported values: openai, gemini, claude, local.");
+    });
+  });
+});
+
+// Minimal vi mock if not provided by a test runner (especially for process.env manipulation)
+// Jest and Vitest typically handle process.env mocking and restoration well.
+// This is more of a conceptual note for environments without such features.
+if (typeof global.vi === 'undefined') {
+  global.vi = {
+    // Mocking for 'vi' is not strictly needed for AiServiceFactory tests as it doesn't use vi.fn() directly
+    // However, if LocalLlmService.test.ts is run in the same context without a test runner, its vi might conflict.
+  } as any; 
+}
+declare global {
+  var vi: any; // Declare vi globally
+}

--- a/src/lib/server/ai/AiServiceFactory.ts
+++ b/src/lib/server/ai/AiServiceFactory.ts
@@ -2,6 +2,7 @@ import { AiService } from "./AiService";
 import { OpenAiService } from "./OpenAiService";
 import { GeminiService } from "./GeminiService";
 import { ClaudeService } from "./ClaudeService";
+import { LocalLlmService } from "./LocalLlmService";
 
 // Helper to read process.env
 const getEnvVar = (
@@ -30,6 +31,8 @@ export class AiServiceFactory {
     const openAiApiKey = getEnvVar("OPENAI_API_KEY");
     const geminiApiKey = getEnvVar("GEMINI_API_KEY");
     const claudeApiKey = getEnvVar("CLAUDE_API_KEY");
+    // No API key needed for local LLM, but it needs a base URI
+    const localLlmBaseUri = getEnvVar("LOCAL_LLM_BASE_URI");
 
     const openAiBaseUri = getEnvVar("OPENAI_BASE_URI");
     const geminiBaseUri = getEnvVar("GEMINI_BASE_URI");
@@ -63,14 +66,20 @@ export class AiServiceFactory {
             claudeApiKey,
             claudeBaseUri as string | undefined
           ); // baseUri is optional
+        case "local":
+        case "localllm": // Adding an alias
+          if (typeof localLlmBaseUri !== "string") {
+            throw new Error("Missing LOCAL_LLM_BASE_URI for local provider.");
+          }
+          return new LocalLlmService(localLlmBaseUri);
         default:
           throw new Error(
-            "Invalid or missing AI_SERVICE_PROVIDER environment variable. Supported values: openai, gemini, claude."
+            "Invalid or missing AI_SERVICE_PROVIDER environment variable. Supported values: openai, gemini, claude, local."
           );
       }
     } else {
       throw new Error(
-        "Invalid or missing AI_SERVICE_PROVIDER environment variable. Supported values: openai, gemini, claude."
+        "Invalid or missing AI_SERVICE_PROVIDER environment variable. Supported values: openai, gemini, claude, local."
       );
     }
   }

--- a/src/lib/server/ai/LocalLlmService.test.ts
+++ b/src/lib/server/ai/LocalLlmService.test.ts
@@ -1,0 +1,109 @@
+import { LocalLlmService } from './LocalLlmService';
+
+// Simple fetch mock
+let mockFetchResponse: any;
+let mockFetchOk: boolean = true;
+let mockFetchStatus: number = 200;
+let fetchShouldThrowError: boolean = false;
+
+global.fetch = vi.fn(async (url: string, options: any): Promise<any> => {
+  if (fetchShouldThrowError) {
+    throw new Error('Network error');
+  }
+  return {
+    ok: mockFetchOk,
+    status: mockFetchStatus,
+    json: async () => mockFetchResponse,
+    text: async () => JSON.stringify(mockFetchResponse), // For error reporting
+  };
+}) as any; // Cast to any to satisfy TypeScript if vi is not actually defined
+
+describe('LocalLlmService', () => {
+  const baseUri = 'http://localhost:11434/api/generate';
+  let localLlmService: LocalLlmService;
+
+  beforeEach(() => {
+    localLlmService = new LocalLlmService(baseUri);
+    // Reset mock states
+    mockFetchOk = true;
+    mockFetchStatus = 200;
+    fetchShouldThrowError = false;
+    mockFetchResponse = {};
+    vi.clearAllMocks(); // Clear mock history if vi is defined
+  });
+
+  test('Test Case 1: Successful response (standard format)', async () => {
+    mockFetchResponse = { response: "Local LLM says hello" };
+    
+    const result = await localLlmService.sendPrompt("Hi");
+    expect(result).toBe("Local LLM says hello");
+    expect(fetch).toHaveBeenCalledWith(baseUri, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ prompt: "Hi", stream: false }),
+    });
+  });
+
+  test('Test Case 2: Successful response (OpenAI-compatible format)', async () => {
+    mockFetchResponse = { choices: [{ message: { content: "OpenAI compatible response" } }] };
+    
+    const result = await localLlmService.sendPrompt("Hi OpenAI");
+    expect(result).toBe("OpenAI compatible response");
+    expect(fetch).toHaveBeenCalledWith(baseUri, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ prompt: "Hi OpenAI", stream: false }),
+    });
+  });
+
+  test('Test Case 3: API error response', async () => {
+    mockFetchOk = false;
+    mockFetchStatus = 500;
+    mockFetchResponse = { error: "Internal Server Error" };
+    
+    await expect(localLlmService.sendPrompt("Hi Error"))
+      .rejects.toThrow('Local LLM API request failed with status 500');
+    expect(fetch).toHaveBeenCalledTimes(1);
+  });
+
+  test('Test Case 4: Network error', async () => {
+    fetchShouldThrowError = true;
+    
+    await expect(localLlmService.sendPrompt("Hi Network Error"))
+      .rejects.toThrow('Network error');
+    expect(fetch).toHaveBeenCalledTimes(1);
+  });
+
+  test('Test Case 5: Invalid response structure', async () => {
+    mockFetchResponse = { data: "something else" }; // Invalid structure
+    
+    await expect(localLlmService.sendPrompt("Hi Invalid Structure"))
+      .rejects.toThrow('Invalid response structure from local LLM.');
+    expect(fetch).toHaveBeenCalledTimes(1);
+  });
+});
+
+// Minimal vi mock if not provided by a test runner
+if (typeof global.vi === 'undefined') {
+  global.vi = {
+    fn: (fnImplementation?: (...args: any[]) => any) => {
+      const mockFn = (...args: any[]) => {
+        mockFn.mock.calls.push(args);
+        return fnImplementation ? fnImplementation(...args) : undefined;
+      };
+      mockFn.mock = { calls: [] };
+      mockFn.mockClear = () => { mockFn.mock.calls = []; };
+      return mockFn;
+    },
+    clearAllMocks: () => {
+      // In a real scenario, this would iterate over all mocks.
+      // For this file, we only care about fetch.
+      if (global.fetch && (global.fetch as any).mock) {
+        (global.fetch as any).mockClear();
+      }
+    },
+  } as any; // Cast to any to avoid TS errors for this minimal mock
+}
+declare global {
+  var vi: any; // Declare vi globally
+}

--- a/src/lib/server/ai/LocalLlmService.ts
+++ b/src/lib/server/ai/LocalLlmService.ts
@@ -1,0 +1,47 @@
+import { AiService } from './AiService';
+
+export class LocalLlmService extends AiService {
+  constructor(baseUri: string) {
+    super(baseUri);
+  }
+
+  async sendPrompt(prompt: string): Promise<any> {
+    try {
+      const response = await fetch(this.baseUri, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          prompt: prompt,
+          stream: false, // Assuming non-streaming for simplicity first
+        }),
+      });
+
+      if (!response.ok) {
+        const errorBody = await response.text();
+        console.error(`Local LLM API request failed with status ${response.status}: ${errorBody}`);
+        throw new Error(`Local LLM API request failed with status ${response.status}`);
+      }
+
+      const data = await response.json();
+      
+      // Assuming the local LLM API returns a JSON object 
+      // with the generated text in a 'response' field.
+      // This might need adjustment based on the specific LLM being used (e.g. Ollama, LocalAI)
+      if (data && data.response) {
+        return data.response;
+      } else if (data && data.choices && data.choices[0] && data.choices[0].message && data.choices[0].message.content) {
+        // Fallback for OpenAI compatible local LLMs (like LocalAI or some Ollama configurations)
+        return data.choices[0].message.content;
+      } else {
+        console.error('Local LLM response did not contain expected data structure:', data);
+        throw new Error('Invalid response structure from local LLM.');
+      }
+
+    } catch (error) {
+      console.error('Error sending prompt to Local LLM:', error);
+      throw error;
+    }
+  }
+}


### PR DESCRIPTION
This commit introduces the capability to use local Large Language Models instead of cloud-based services.

Key changes include:

- Added `LocalLlmService.ts`: A new service that implements the `AiService` interface to communicate with a local LLM endpoint. It supports standard JSON responses (e.g., `{"response": "..."}`) and OpenAI-compatible API formats (e.g., `{"choices": [{"message": {"content": "..."}}]}`).
- Updated `AiServiceFactory.ts`: Modified to recognize "local" or "localllm" as an `AI_SERVICE_PROVIDER`. It now uses the `LOCAL_LLM_BASE_URI` environment variable to instantiate `LocalLlmService`.
- Updated `.env.example`: Added `LOCAL_LLM_BASE_URI` with examples for Ollama and generic OpenAI-compatible local servers. Also included "local" as an option for `AI_SERVICE_PROVIDER`.
- Added Tests:
    - `LocalLlmService.test.ts`: Unit tests for `LocalLlmService`, covering successful API interactions, error handling, and different response formats.
    - `AiServiceFactory.test.ts`: Tests for `AiServiceFactory` to ensure correct instantiation of `LocalLlmService` and handling of missing configuration.
- Updated `README.md`: Provided documentation on how to configure and use local LLMs, including the new environment variables and expected API behavior. Updated the project roadmap to reflect this addition.