### PR TITLE
feat: Add user settings page and update functionality

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
         "@sveltejs/vite-plugin-svelte": "^3.0.2",
         "@tailwindcss/typography": "^0.5.10",
         "@types/better-sqlite3": "^7.6.13",
-        "bcrypt": "^6.0.0",
         "better-sqlite3": "^11.10.0",
         "dotenv": "^16.5.0",
         "jspdf": "^2.5.2",
@@ -26,7 +25,9 @@
         "@sveltejs/kit": "^2.0.0",
         "@types/bcrypt": "^5.0.2",
         "@types/luxon": "^3.2.0",
+        "@vitest/ui": "^3.2.0",
         "autoprefixer": "^10.4.21",
+        "bcrypt": "^6.0.0",
         "jsonc-parser": "^3.3.1",
         "playwright": "^1.52.0",
         "postcss": "^8.5.3",
@@ -36,7 +37,7 @@
         "tslib": "^2.4.1",
         "typescript": "^5.0.0",
         "vite": "^5.0.0",
-        "vitest": "^3.1.4"
+        "vitest": "^3.2.0"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -1235,7 +1236,6 @@
       "resolved": "https://registry.npmjs.org/@types/bcrypt/-/bcrypt-5.0.2.tgz",
       "integrity": "sha512-6atioO8Y75fNcbmj0G7UjI9lXN2pQ/IGJ2FWT4a/btd0Lk9lQalHLKhkgKVZ3r+spnmWUKfbMi1GEe9wyHQfNQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@types/node": "*"
       }
@@ -1249,12 +1249,27 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.2.tgz",
+      "integrity": "sha512-8kB30R7Hwqf40JPiKhVzodJs2Qc1ZJ5zuT3uzw5Hq/dhNCl3G3l83jfpdI1e20BP348+fV7VIL/+FxaXkqBmWg==",
+      "dev": true,
+      "dependencies": {
+        "@types/deep-eql": "*"
+      }
+    },
     "node_modules/@types/cookie": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.6.0.tgz",
       "integrity": "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true
     },
     "node_modules/@types/estree": {
       "version": "1.0.7",
@@ -1313,14 +1328,14 @@
       }
     },
     "node_modules/@vitest/expect": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.1.4.tgz",
-      "integrity": "sha512-xkD/ljeliyaClDYqHPNCiJ0plY5YIcM0OlRiZizLhlPmpXWpxnGMyTZXOHFhFeG7w9P5PBeL4IdtJ/HeQwTbQA==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.0.tgz",
+      "integrity": "sha512-0v4YVbhDKX3SKoy0PHWXpKhj44w+3zZkIoVES9Ex2pq+u6+Bijijbi2ua5kE+h3qT6LBWFTNZSCOEU37H8Y5sA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "3.1.4",
-        "@vitest/utils": "3.1.4",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.0",
+        "@vitest/utils": "3.2.0",
         "chai": "^5.2.0",
         "tinyrainbow": "^2.0.0"
       },
@@ -1329,13 +1344,12 @@
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.1.4.tgz",
-      "integrity": "sha512-8IJ3CvwtSw/EFXqWFL8aCMu+YyYXG2WUSrQbViOZkWTKTVicVwZ/YiEZDSqD00kX+v/+W+OnxhNWoeVKorHygA==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.0.tgz",
+      "integrity": "sha512-HFcW0lAMx3eN9vQqis63H0Pscv0QcVMo1Kv8BNysZbxcmHu3ZUYv59DS6BGYiGQ8F5lUkmsfMMlPm4DJFJdf/A==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "3.1.4",
+        "@vitest/spy": "3.2.0",
         "estree-walker": "^3.0.3",
         "magic-string": "^0.30.17"
       },
@@ -1344,7 +1358,7 @@
       },
       "peerDependencies": {
         "msw": "^2.4.9",
-        "vite": "^5.0.0 || ^6.0.0"
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
       },
       "peerDependenciesMeta": {
         "msw": {
@@ -1360,17 +1374,15 @@
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
       "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@types/estree": "^1.0.0"
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.1.4.tgz",
-      "integrity": "sha512-cqv9H9GvAEoTaoq+cYqUTCGscUjKqlJZC7PRwY5FMySVj5J+xOm1KQcCiYHJOEzOKRUhLH4R2pTwvFlWCEScsg==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.0.tgz",
+      "integrity": "sha512-gUUhaUmPBHFkrqnOokmfMGRBMHhgpICud9nrz/xpNV3/4OXCn35oG+Pl8rYYsKaTNd/FAIrqRHnwpDpmYxCYZw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "tinyrainbow": "^2.0.0"
       },
@@ -1379,13 +1391,12 @@
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.1.4.tgz",
-      "integrity": "sha512-djTeF1/vt985I/wpKVFBMWUlk/I7mb5hmD5oP8K9ACRmVXgKTae3TUOtXAEBfslNKPzUQvnKhNd34nnRSYgLNQ==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.0.tgz",
+      "integrity": "sha512-bXdmnHxuB7fXJdh+8vvnlwi/m1zvu+I06i1dICVcDQFhyV4iKw2RExC/acavtDn93m/dRuawUObKsrNE1gJacA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "3.1.4",
+        "@vitest/utils": "3.2.0",
         "pathe": "^2.0.3"
       },
       "funding": {
@@ -1393,13 +1404,12 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.1.4.tgz",
-      "integrity": "sha512-JPHf68DvuO7vilmvwdPr9TS0SuuIzHvxeaCkxYcCD4jTk67XwL45ZhEHFKIuCm8CYstgI6LZ4XbwD6ANrwMpFg==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.0.tgz",
+      "integrity": "sha512-z7P/EneBRMe7hdvWhcHoXjhA6at0Q4ipcoZo6SqgxLyQQ8KSMMCmvw1cSt7FHib3ozt0wnRHc37ivuUMbxzG/A==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "3.1.4",
+        "@vitest/pretty-format": "3.2.0",
         "magic-string": "^0.30.17",
         "pathe": "^2.0.3"
       },
@@ -1408,26 +1418,45 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.1.4.tgz",
-      "integrity": "sha512-Xg1bXhu+vtPXIodYN369M86K8shGLouNjoVI78g8iAq2rFoHFdajNvJJ5A/9bPMFcfQqdaCpOgWKEoMQg/s0Yg==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.0.tgz",
+      "integrity": "sha512-s3+TkCNUIEOX99S0JwNDfsHRaZDDZZR/n8F0mop0PmsEbQGKZikCGpTGZ6JRiHuONKew3Fb5//EPwCP+pUX9cw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "tinyspy": "^3.0.2"
+        "tinyspy": "^4.0.3"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
-    "node_modules/@vitest/utils": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.1.4.tgz",
-      "integrity": "sha512-yriMuO1cfFhmiGc8ataN51+9ooHRuURdfAZfwFd3usWynjzpLslZdYnRegTv32qdgtJTsj15FoeZe2g15fY1gg==",
+    "node_modules/@vitest/ui": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@vitest/ui/-/ui-3.2.0.tgz",
+      "integrity": "sha512-cYFZZSl1usgzsHoGF66GHfYXlEwc06ggapS1TaSLMKCzhTPWBPI9b/t1RvKIsLSjdKUakpSPf33jQMvRjMvvlQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "3.1.4",
+        "@vitest/utils": "3.2.0",
+        "fflate": "^0.8.2",
+        "flatted": "^3.3.3",
+        "pathe": "^2.0.3",
+        "sirv": "^3.0.1",
+        "tinyglobby": "^0.2.14",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "vitest": "3.2.0"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.0.tgz",
+      "integrity": "sha512-gXXOe7Fj6toCsZKVQouTRLJftJwmvbhH5lKOBR6rlP950zUq9AitTUjnFoXS/CqjBC2aoejAztLPzzuva++XBw==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.0",
         "loupe": "^3.1.3",
         "tinyrainbow": "^2.0.0"
       },
@@ -1615,7 +1644,6 @@
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
       "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=12"
       }
@@ -1725,8 +1753,8 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/bcrypt/-/bcrypt-6.0.0.tgz",
       "integrity": "sha512-cU8v/EGSrnH+HnxV2z0J7/blxH8gq7Xh2JFT6Aroax7UohdmiJJlxApMxtKfuI7z68NvvVcmR78k2LbT6efhRg==",
+      "dev": true,
       "hasInstallScript": true,
-      "license": "MIT",
       "dependencies": {
         "node-addon-api": "^8.3.0",
         "node-gyp-build": "^4.8.4"
@@ -1928,7 +1956,6 @@
       "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
       "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -2027,7 +2054,6 @@
       "resolved": "https://registry.npmjs.org/chai/-/chai-5.2.0.tgz",
       "integrity": "sha512-mCuXncKXk5iCLhfhwTc0izo0gtEmpz5CtG2y8GiOINBlMVS6v8TMRc5TaLWKS6692m9+dVVfzgeVxR5UxWHTYw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "assertion-error": "^2.0.1",
         "check-error": "^2.1.1",
@@ -2044,7 +2070,6 @@
       "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.1.tgz",
       "integrity": "sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">= 16"
       }
@@ -2475,7 +2500,6 @@
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
       "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
@@ -2669,8 +2693,7 @@
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
       "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
@@ -3147,6 +3170,12 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/flatted": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
+      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "dev": true
     },
     "node_modules/foreground-child": {
       "version": "3.3.1",
@@ -4166,8 +4195,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.1.3.tgz",
       "integrity": "sha512-kkIp7XSkP78ZxJEsSxW3712C6teJVoeHHwgo9zJ380de7IYyJ2ISlxojcH2pC5OFLewESmnRi/+XCDIEEVyoug==",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/lru-cache": {
       "version": "10.4.3",
@@ -4461,6 +4489,7 @@
       "version": "8.3.1",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.3.1.tgz",
       "integrity": "sha512-lytcDEdxKjGJPTLEfW4mYMigRezMlyJY8W4wxJK8zE533Jlb8L8dRuObJFWg2P+AuOIxoCgKF+2Oq4d4Zd0OUA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^18 || ^20 || >= 21"
@@ -4510,6 +4539,7 @@
       "version": "4.8.4",
       "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
       "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
+      "dev": true,
       "license": "MIT",
       "bin": {
         "node-gyp-build": "bin.js",
@@ -4734,7 +4764,6 @@
       "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.0.tgz",
       "integrity": "sha512-vE7JKRyES09KiunauX7nd2Q9/L7lhok4smP9RZTDeD4MVs72Dp2qNFVz39Nz5a0FVEW0BJR6C0DYrq6unoziZA==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">= 14.16"
       }
@@ -6390,11 +6419,10 @@
       }
     },
     "node_modules/tinypool": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.0.2.tgz",
-      "integrity": "sha512-al6n+QEANGFOMf/dmUMsuS5/r9B06uwlyNjZZql/zv8J7ybHCgoihBNORZCY2mzUuAnomQa2JdhyHKzZxPCrFA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.0.tgz",
+      "integrity": "sha512-7CotroY9a8DKsKprEy/a14aCCm8jYVmR7aFy4fpkZM8sdpNJbKkixuNjgM50yCmip2ezc8z4N7k3oe2+rfRJCQ==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": "^18.0.0 || >=20.0.0"
       }
@@ -6410,11 +6438,10 @@
       }
     },
     "node_modules/tinyspy": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
-      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.3.tgz",
+      "integrity": "sha512-t2T/WLB2WRgZ9EpE4jgPJ9w+i66UZfDc8wHh0xrwiRNN+UwH98GIJkTeZqX9rg0i0ptwzqW+uYeIF0T4F8LR7A==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
       }
@@ -6705,17 +6732,16 @@
       }
     },
     "node_modules/vite-node": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.1.4.tgz",
-      "integrity": "sha512-6enNwYnpyDo4hEgytbmc6mYWHXDHYEn0D1/rw4Q+tnHUGtKTJsn8T1YkX6Q18wI5LCrS8CTYlBaiCqxOy2kvUA==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.0.tgz",
+      "integrity": "sha512-8Fc5Ko5Y4URIJkmMF/iFP1C0/OJyY+VGVe9Nw6WAdZyw4bTO+eVg9mwxWkQp/y8NnAoQY3o9KAvE1ZdA2v+Vmg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "cac": "^6.7.14",
-        "debug": "^4.4.0",
+        "debug": "^4.4.1",
         "es-module-lexer": "^1.7.0",
         "pathe": "^2.0.3",
-        "vite": "^5.0.0 || ^6.0.0"
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
       },
       "bin": {
         "vite-node": "vite-node.mjs"
@@ -7162,32 +7188,33 @@
       }
     },
     "node_modules/vitest": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.1.4.tgz",
-      "integrity": "sha512-Ta56rT7uWxCSJXlBtKgIlApJnT6e6IGmTYxYcmxjJ4ujuZDI59GUQgVDObXXJujOmPDBYXHK1qmaGtneu6TNIQ==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.0.tgz",
+      "integrity": "sha512-P7Nvwuli8WBNmeMHHek7PnGW4oAZl9za1fddfRVidZar8wDZRi7hpznLKQePQ8JPLwSBEYDK11g+++j7uFJV8Q==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@vitest/expect": "3.1.4",
-        "@vitest/mocker": "3.1.4",
-        "@vitest/pretty-format": "^3.1.4",
-        "@vitest/runner": "3.1.4",
-        "@vitest/snapshot": "3.1.4",
-        "@vitest/spy": "3.1.4",
-        "@vitest/utils": "3.1.4",
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.0",
+        "@vitest/mocker": "3.2.0",
+        "@vitest/pretty-format": "^3.2.0",
+        "@vitest/runner": "3.2.0",
+        "@vitest/snapshot": "3.2.0",
+        "@vitest/spy": "3.2.0",
+        "@vitest/utils": "3.2.0",
         "chai": "^5.2.0",
-        "debug": "^4.4.0",
+        "debug": "^4.4.1",
         "expect-type": "^1.2.1",
         "magic-string": "^0.30.17",
         "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
         "std-env": "^3.9.0",
         "tinybench": "^2.9.0",
         "tinyexec": "^0.3.2",
-        "tinyglobby": "^0.2.13",
-        "tinypool": "^1.0.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.0",
         "tinyrainbow": "^2.0.0",
-        "vite": "^5.0.0 || ^6.0.0",
-        "vite-node": "3.1.4",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.0",
         "why-is-node-running": "^2.3.0"
       },
       "bin": {
@@ -7203,8 +7230,8 @@
         "@edge-runtime/vm": "*",
         "@types/debug": "^4.1.12",
         "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
-        "@vitest/browser": "3.1.4",
-        "@vitest/ui": "3.1.4",
+        "@vitest/browser": "3.2.0",
+        "@vitest/ui": "3.2.0",
         "happy-dom": "*",
         "jsdom": "*"
       },

--- a/package.json
+++ b/package.json
@@ -16,7 +16,9 @@
     "@sveltejs/kit": "^2.0.0",
     "@types/bcrypt": "^5.0.2",
     "@types/luxon": "^3.2.0",
+    "@vitest/ui": "^3.2.0",
     "autoprefixer": "^10.4.21",
+    "bcrypt": "^6.0.0",
     "jsonc-parser": "^3.3.1",
     "playwright": "^1.52.0",
     "postcss": "^8.5.3",
@@ -26,14 +28,13 @@
     "tslib": "^2.4.1",
     "typescript": "^5.0.0",
     "vite": "^5.0.0",
-    "vitest": "^3.1.4"
+    "vitest": "^3.2.0"
   },
   "dependencies": {
     "@google/genai": "^1.0.1",
     "@sveltejs/vite-plugin-svelte": "^3.0.2",
     "@tailwindcss/typography": "^0.5.10",
     "@types/better-sqlite3": "^7.6.13",
-    "bcrypt": "^6.0.0",
     "better-sqlite3": "^11.10.0",
     "dotenv": "^16.5.0",
     "jspdf": "^2.5.2",

--- a/src/lib/server/auth.test.ts
+++ b/src/lib/server/auth.test.ts
@@ -1,0 +1,348 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  hashPassword,
+  validatePassword,
+  updateUserName,
+  updateUserEmail,
+  updateUserPassword,
+  registerUser, // Assuming registerUser might be useful for setup or also needs testing
+  loginUser,
+  validateSession,
+  logoutUser
+} from './auth';
+import { userDb, sessionDb } from './db'; // We will mock these
+
+// Mock the entire db module
+vi.mock('./db', () => {
+  // Mock user structure
+  const mockUser = {
+    id: 'user1',
+    name: 'Original Name',
+    email: 'original@example.com',
+    passwordHash: 'hashedPasswordOriginal',
+  };
+
+  const mockAdminUser = {
+    id: 'adminUser',
+    name: 'Admin User',
+    email: 'admin@example.com',
+    passwordHash: 'hashedPasswordAdmin',
+  }
+
+  // In-memory store for users for more realistic testing
+  let usersStore: Record<string, any> = {
+    [mockUser.id]: { ...mockUser },
+    [mockAdminUser.id]: { ...mockAdminUser }
+  };
+
+  let sessionsStore: Record<string, any> = {};
+
+
+  return {
+    userDb: {
+      findById: vi.fn((id: string) => usersStore[id] ? { ...usersStore[id] } : undefined),
+      findByEmail: vi.fn((email: string) => Object.values(usersStore).find(u => u.email === email)),
+      createUser: vi.fn((userData: any) => {
+        const newUser = { id: `user${Object.keys(usersStore).length + 1}`, ...userData };
+        usersStore[newUser.id] = newUser;
+        return newUser;
+      }),
+      updateUser: vi.fn((userId: string, dataToUpdate: any) => {
+        if (!usersStore[userId]) return undefined;
+        usersStore[userId] = { ...usersStore[userId], ...dataToUpdate };
+        return { ...usersStore[userId] };
+      }),
+      // Utility to reset store for tests
+      _resetStore: () => {
+        usersStore = {
+            [mockUser.id]: { ...mockUser },
+            [mockAdminUser.id]: { ...mockAdminUser }
+        };
+      },
+      _users: usersStore // Expose for direct manipulation in tests if necessary (use with caution)
+    },
+    sessionDb: {
+      createSession: vi.fn((userId: string) => {
+        const sessionId = `session${Object.keys(sessionsStore).length + 1}`;
+        const session = { id: sessionId, userId, expiresAt: new Date(Date.now() + 3600 * 1000).toISOString() };
+        sessionsStore[sessionId] = session;
+        return session;
+      }),
+      findById: vi.fn((id: string) => sessionsStore[id] ? { ...sessionsStore[id] } : undefined),
+      deleteSession: vi.fn((id: string) => {
+        if (sessionsStore[id]) {
+          delete sessionsStore[id];
+          return true;
+        }
+        return false;
+      }),
+      deleteAllUserSessions: vi.fn((userId: string) => {
+        let deleted = false;
+        for (const id in sessionsStore) {
+          if (sessionsStore[id].userId === userId) {
+            delete sessionsStore[id];
+            deleted = true;
+          }
+        }
+        return deleted;
+      }),
+      _resetStore: () => {
+        sessionsStore = {};
+      }
+    }
+  };
+});
+
+describe('Auth Functions', () => {
+  beforeEach(() => {
+    // Reset mocks and stores before each test
+    vi.clearAllMocks();
+    (userDb as any)._resetStore();
+    (sessionDb as any)._resetStore();
+  });
+
+  describe('hashPassword and validatePassword', () => {
+    it('should hash a password and then validate it successfully', async () => {
+      const password = 'mySecurePassword123';
+      const hashedPassword = await hashPassword(password);
+      expect(hashedPassword).not.toBe(password);
+      expect(await validatePassword(password, hashedPassword)).toBe(true);
+    });
+
+    it('should fail to validate an incorrect password', async () => {
+      const password = 'mySecurePassword123';
+      const wrongPassword = 'wrongPassword';
+      const hashedPassword = await hashPassword(password);
+      expect(await validatePassword(wrongPassword, hashedPassword)).toBe(false);
+    });
+  });
+
+  describe('updateUserName', () => {
+    const userId = 'user1';
+    it('should update user name successfully', async () => {
+      const newName = 'New Name';
+      const result = await updateUserName(userId, newName);
+      expect(result).toBe(true);
+      expect(userDb.findById).toHaveBeenCalledWith(userId);
+      expect(userDb.updateUser).toHaveBeenCalledWith(userId, { name: newName });
+      // Check if the name was actually updated in our mock DB
+      const updatedUser = (userDb.findById as any)(userId);
+      expect(updatedUser.name).toBe(newName);
+    });
+
+    it('should return false if name is empty', async () => {
+      const result = await updateUserName(userId, '');
+      expect(result).toBe(false);
+      expect(userDb.updateUser).not.toHaveBeenCalled();
+    });
+
+    it('should return false if user is not found', async () => {
+      const result = await updateUserName('nonExistentUser', 'New Name');
+      expect(result).toBe(false);
+      expect(userDb.updateUser).not.toHaveBeenCalled();
+    });
+     it('should return false if userId is empty', async () => {
+      const result = await updateUserName('', 'New Name');
+      expect(result).toBe(false);
+      expect(userDb.findById).not.toHaveBeenCalled();
+      expect(userDb.updateUser).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('updateUserEmail', () => {
+    const userId = 'user1'; // Belongs to original@example.com
+    const otherUserId = 'adminUser'; // Belongs to admin@example.com
+
+    it('should update user email successfully', async () => {
+      const newEmail = 'updated@example.com';
+      const result = await updateUserEmail(userId, newEmail);
+      expect(result).toBe(true);
+      expect(userDb.findById).toHaveBeenCalledWith(userId);
+      expect(userDb.findByEmail).toHaveBeenCalledWith(newEmail);
+      expect(userDb.updateUser).toHaveBeenCalledWith(userId, { email: newEmail });
+      const updatedUser = (userDb.findById as any)(userId);
+      expect(updatedUser.email).toBe(newEmail);
+    });
+
+    it('should return false if email format is invalid', async () => {
+      const result = await updateUserEmail(userId, 'invalid-email');
+      expect(result).toBe(false);
+      expect(userDb.updateUser).not.toHaveBeenCalled();
+    });
+
+    it('should return false if user is not found', async () => {
+      const result = await updateUserEmail('nonExistentUser', 'new@example.com');
+      expect(result).toBe(false);
+      expect(userDb.updateUser).not.toHaveBeenCalled();
+    });
+
+    it('should return false if new email already exists for another user', async () => {
+      const result = await updateUserEmail(userId, 'admin@example.com'); // adminUser's email
+      expect(result).toBe(false);
+      expect(userDb.updateUser).not.toHaveBeenCalled();
+    });
+
+    it('should allow updating to the same email for the current user', async () => {
+      const result = await updateUserEmail(userId, 'original@example.com');
+      expect(result).toBe(true); // Should this be true or false? Current logic allows it.
+                                 // Assuming it means "no change needed" thus success.
+      expect(userDb.updateUser).toHaveBeenCalledWith(userId, { email: 'original@example.com' });
+    });
+     it('should return false if userId is empty', async () => {
+      const result = await updateUserEmail('', 'new@example.com');
+      expect(result).toBe(false);
+      expect(userDb.findById).not.toHaveBeenCalled();
+      expect(userDb.updateUser).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('updateUserPassword', () => {
+    const userId = 'user1';
+    it('should update user password successfully', async () => {
+      const newPassword = 'newPassword123';
+      const result = await updateUserPassword(userId, newPassword);
+      expect(result).toBe(true);
+      expect(userDb.findById).toHaveBeenCalledWith(userId);
+      expect(userDb.updateUser).toHaveBeenCalledWith(userId, { passwordHash: expect.any(String) });
+
+      const updatedUser = (userDb.findById as any)(userId);
+      expect(await validatePassword(newPassword, updatedUser.passwordHash)).toBe(true);
+      expect(updatedUser.passwordHash).not.toBe('hashedPasswordOriginal');
+    });
+
+    it('should return false if password is too weak', async () => {
+      const result = await updateUserPassword(userId, 'weak');
+      expect(result).toBe(false);
+      expect(userDb.updateUser).not.toHaveBeenCalled();
+    });
+
+    it('should return false if password does not meet regex (no number)', async () => {
+      const result = await updateUserPassword(userId, 'passwordonlyletters');
+      expect(result).toBe(false);
+      expect(userDb.updateUser).not.toHaveBeenCalled();
+    });
+
+    it('should return false if password does not meet regex (no letter)', async () => {
+      const result = await updateUserPassword(userId, '1234567890');
+      expect(result).toBe(false);
+      expect(userDb.updateUser).not.toHaveBeenCalled();
+    });
+
+    it('should return false if user is not found', async () => {
+      const result = await updateUserPassword('nonExistentUser', 'newPassword123');
+      expect(result).toBe(false);
+      expect(userDb.updateUser).not.toHaveBeenCalled();
+    });
+    it('should return false if userId is empty', async () => {
+      const result = await updateUserPassword('', 'newPassword123');
+      expect(result).toBe(false);
+      expect(userDb.findById).not.toHaveBeenCalled();
+      expect(userDb.updateUser).not.toHaveBeenCalled();
+    });
+  });
+
+  // Basic tests for other auth functions if time permits or if they are critical for update logic
+  describe('registerUser', () => {
+    it('should register a new user successfully', async () => {
+      const newUser = await registerUser('test@example.com', 'Password123', 'Test User');
+      expect(newUser).toBeDefined();
+      expect(newUser?.email).toBe('test@example.com');
+      expect(userDb.findByEmail).toHaveBeenCalledWith('test@example.com');
+      expect(userDb.createUser).toHaveBeenCalled();
+    });
+
+    it('should throw error if email already exists during registration', async () => {
+      // First user registration is fine
+      await registerUser('existing@example.com', 'Password123', 'Existing User');
+      // Attempt to register again with the same email
+      await expect(registerUser('existing@example.com', 'Password123', 'Another User'))
+        .rejects.toThrow('User with this email already exists');
+    });
+  });
+
+  describe('loginUser', () => {
+    it('should login an existing user successfully', async () => {
+      // Ensure 'original@example.com' with 'hashedPasswordOriginal' (from mockUser) exists.
+      // The mock for validatePassword needs to be realistic for login.
+      // For this test, we assume 'hashedPasswordOriginal' is the hash of 'ValidPass123'
+      // We need to ensure our mock validatePassword works or pre-hash a password.
+      // The actual hashPassword and validatePassword are used, so this should be fine.
+
+      const loginPassword = "passwordForUser1";
+      const originalUser = (userDb.findById as any)('user1');
+      originalUser.passwordHash = await hashPassword(loginPassword); // Set a known password hash
+      (userDb.updateUser as any)('user1', { passwordHash: originalUser.passwordHash});
+
+
+      const { sessionId, user } = await loginUser('original@example.com', loginPassword);
+      expect(sessionId).toEqual(expect.any(String));
+      expect(user.email).toBe('original@example.com');
+      expect(sessionDb.createSession).toHaveBeenCalledWith('user1');
+    });
+
+    it('should throw error for non-existent user during login', async () => {
+      await expect(loginUser('nosuchuser@example.com', 'Password123'))
+        .rejects.toThrow("This user doesn't exists");
+    });
+
+    it('should throw error for invalid password during login', async () => {
+       const loginPassword = "passwordForUser1";
+       const originalUser = (userDb.findById as any)('user1');
+       originalUser.passwordHash = await hashPassword(loginPassword);
+      (userDb.updateUser as any)('user1', { passwordHash: originalUser.passwordHash});
+
+      await expect(loginUser('original@example.com', 'WrongPassword123'))
+        .rejects.toThrow('Invalid password or email');
+    });
+  });
+
+  describe('validateSession', () => {
+    it('should validate a correct session and return user details', async () => {
+      const loginPassword = "passwordForUser1";
+      const originalUserRaw = (userDb.findById as any)('user1');
+      originalUserRaw.passwordHash = await hashPassword(loginPassword);
+      (userDb.updateUser as any)('user1', { passwordHash: originalUserRaw.passwordHash});
+
+      const { sessionId } = await loginUser('original@example.com', loginPassword);
+      const user = validateSession(sessionId);
+      expect(user).toBeDefined();
+      expect(user?.email).toBe('original@example.com');
+      expect(user).not.toHaveProperty('passwordHash');
+    });
+
+    it('should return null for an invalid session ID', () => {
+      expect(validateSession('invalidSessionId')).toBeNull();
+    });
+
+    it('should return null if session is expired', () => {
+      const session = (sessionDb.createSession as any)('user1');
+      // Manually expire the session
+      (sessionDb.findById as any).mockImplementationOnce((id: string) => {
+        if (id === session.id) {
+            return { ...session, expiresAt: new Date(Date.now() - 1000).toISOString() };
+        }
+        return undefined;
+      });
+      expect(validateSession(session.id)).toBeNull();
+      expect(sessionDb.deleteSession).toHaveBeenCalledWith(session.id);
+    });
+  });
+
+  describe('logoutUser', () => {
+    it('should logout a user by deleting their session', async () => {
+      const loginPassword = "passwordForUser1";
+      const originalUserRaw = (userDb.findById as any)('user1');
+      originalUserRaw.passwordHash = await hashPassword(loginPassword);
+      (userDb.updateUser as any)('user1', { passwordHash: originalUserRaw.passwordHash});
+
+      const { sessionId } = await loginUser('original@example.com', loginPassword);
+      expect(logoutUser(sessionId)).toBe(true);
+      expect(sessionDb.deleteSession).toHaveBeenCalledWith(sessionId);
+      expect((sessionDb.findById as any)(sessionId)).toBeUndefined();
+    });
+
+    it('should return false if session ID to logout is not found', () => {
+      expect(logoutUser('nonExistentSessionId')).toBe(false);
+    });
+  });
+});

--- a/src/routes/(main)/settings/+page.svelte
+++ b/src/routes/(main)/settings/+page.svelte
@@ -1,0 +1,85 @@
+<script lang="ts">
+  let name = "John Doe"; // Placeholder name
+  let email = "john.doe@example.com"; // Placeholder email
+  let newPassword = "";
+
+  function saveChanges() {
+    // Handle saving changes here
+    console.log("Name:", name);
+    console.log("Email:", email);
+    console.log("New Password:", newPassword);
+    // In a real application, you would send this data to a backend server
+  }
+</script>
+
+<style>
+  .settings-form {
+    max-width: 500px;
+    margin: 2rem auto;
+    padding: 2rem;
+    border: 1px solid #ccc;
+    border-radius: 8px;
+    background-color: #f9f9f9;
+  }
+
+  .form-group {
+    margin-bottom: 1rem;
+  }
+
+  label {
+    display: block;
+    margin-bottom: 0.5rem;
+    font-weight: bold;
+  }
+
+  input[type="text"],
+  input[type="email"],
+  input[type="password"] {
+    width: 100%;
+    padding: 0.5rem;
+    border: 1px solid #ddd;
+    border-radius: 4px;
+    box-sizing: border-box;
+  }
+
+  button {
+    background-color: #007bff;
+    color: white;
+    padding: 0.75rem 1.5rem;
+    border: none;
+    border-radius: 4px;
+    cursor: pointer;
+    font-size: 1rem;
+  }
+
+  button:hover {
+    background-color: #0056b3;
+  }
+
+  h1 {
+    text-align: center;
+    margin-bottom: 1.5rem;
+  }
+</style>
+
+<div class="settings-form">
+  <h1>Settings</h1>
+  <form on:submit|preventDefault={saveChanges}>
+    <div class="form-group">
+      <label for="name">Name</label>
+      <input type="text" id="name" bind:value={name} />
+    </div>
+
+    <div class="form-group">
+      <label for="email">Email</label>
+      <input type="email" id="email" bind:value={email} />
+    </div>
+
+    <div class="form-group">
+      <label for="newPassword">New Password</label>
+      <input type="password" id="newPassword" bind:value={newPassword} />
+    </div>
+
+    <button type="submit">Save changes</button>
+  </form>
+</div>

--- a/src/routes/api/user/update/+server.ts
+++ b/src/routes/api/user/update/+server.ts
@@ -1,0 +1,116 @@
+import type { RequestHandler } from '@sveltejs/kit';
+import { json } from '@sveltejs/kit';
+import {
+  validateSession,
+  updateUserName,
+  updateUserEmail,
+  updateUserPassword
+} from '$lib/server/auth'; // Adjusted path assuming $lib alias
+
+export const POST: RequestHandler = async ({ request, cookies }) => {
+  try {
+    const sessionId = cookies.get('sessionId');
+    if (!sessionId) {
+      return json({ success: false, message: 'Unauthorized. No session cookie provided.' }, { status: 401 });
+    }
+
+    const user = validateSession(sessionId);
+    if (!user) {
+      return json({ success: false, message: 'Unauthorized. Invalid or expired session.' }, { status: 401 });
+    }
+
+    let body;
+    try {
+      body = await request.json();
+    } catch (e) {
+      if (e instanceof SyntaxError) {
+        return json({ success: false, message: 'Invalid JSON in request body.' }, { status: 400 });
+      }
+      throw e; // Re-throw other errors
+    }
+
+    const { name, email, password } = body;
+
+    if (!name && !email && !password) {
+      return json(
+        { success: false, message: 'No data provided for update. Please provide name, email, or password.' },
+        { status: 400 }
+      );
+    }
+
+    const results: { field?: string, success: boolean, message: string }[] = [];
+    let overallSuccess = true;
+
+    if (name !== undefined) {
+      if (typeof name !== 'string') {
+        results.push({ field: 'name', success: false, message: 'Name must be a string.' });
+        overallSuccess = false;
+      } else {
+        const nameUpdateSuccess = await updateUserName(user.id, name);
+        results.push({
+          field: 'name',
+          success: nameUpdateSuccess,
+          message: nameUpdateSuccess ? 'Name updated successfully.' : 'Failed to update name.'
+        });
+        if (!nameUpdateSuccess) overallSuccess = false;
+      }
+    }
+
+    if (email !== undefined) {
+      if (typeof email !== 'string') {
+        results.push({ field: 'email', success: false, message: 'Email must be a string.' });
+        overallSuccess = false;
+      } else {
+        const emailUpdateSuccess = await updateUserEmail(user.id, email);
+        results.push({
+          field: 'email',
+          success: emailUpdateSuccess,
+          message: emailUpdateSuccess ? 'Email updated successfully.' : 'Failed to update email (e.g., invalid format or already in use).'
+        });
+        if (!emailUpdateSuccess) overallSuccess = false;
+      }
+    }
+
+    if (password !== undefined) {
+      if (typeof password !== 'string') {
+        results.push({ field: 'password', success: false, message: 'Password must be a string.' });
+        overallSuccess = false;
+      } else {
+        const passwordUpdateSuccess = await updateUserPassword(user.id, password);
+        results.push({
+          field: 'password',
+          success: passwordUpdateSuccess,
+          message: passwordUpdateSuccess ? 'Password updated successfully.' : 'Failed to update password (e.g., does not meet security requirements).'
+        });
+        if (!passwordUpdateSuccess) overallSuccess = false;
+      }
+    }
+
+    if (results.length === 0) { // Should not happen if initial check for no data is correct
+        return json(
+            { success: false, message: 'No updatable fields provided.' },
+            { status: 400 }
+        );
+    }
+
+    if (overallSuccess) {
+      return json(
+        { success: true, message: 'User data updated successfully.', details: results },
+        { status: 200 }
+      );
+    } else {
+      return json(
+        { success: false, message: 'One or more updates failed.', details: results },
+        { status: 400 } // Or 207 Multi-Status if some succeeded and some failed
+      );
+    }
+
+  } catch (error) {
+    console.error('Error processing /api/user/update request:', error);
+    // Catching SyntaxError for request.json() is now handled above
+    return json(
+      { success: false, message: 'An unexpected server error occurred.' },
+      { status: 500 }
+    );
+  }
+};


### PR DESCRIPTION
This commit introduces a new user settings page where you can update your profile information (name, email) and password.

Key changes:
- Added a new route `/(main)/settings/+page.svelte` for the settings page UI.
- Created an API endpoint `/api/user/update/+server.ts` to handle POST requests for updating user data.
- Added `updateUserName`, `updateUserEmail`, and `updateUserPassword` functions to `src/lib/server/auth.ts` to manage the update logic, including input validation and interaction with the database (currently mocked `userDb`).
- The API endpoint now validates your session before processing any updates.
- Added comprehensive unit tests for the new functions in `src/lib/server/auth.ts`. These tests cover various success and failure scenarios.
- The settings page currently uses placeholder data and will be connected to the backend in a subsequent step.